### PR TITLE
docs: Fix logo and other updates

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,10 @@
 # The Atsign Company
 
-<img width=250px src="https://atsign.dev/assets/img/@platform_logo_grey.svg?sanitize=true">
+<!-- pyml disable-num-lines 4 md013,md033-->
+<a href="https://atsign.com#gh-light-mode-only">
+   <img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a>
+<a href="https://atsign.com#gh-dark-mode-only">
+   <img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
 
 Welcome to the Atsign Github Organization, home to the creators of
 [The atPlatform](https://docs.atsign.com).
@@ -14,6 +18,10 @@ org, which hosts the open source repos for the atPlatform.
 These repos hold open source projects that aren't part of the atPlatform,
 which is why they're here rather than over at The Atsign Foundation.
 
+* [at_dockerfiles](https://github.com/atsign-company/at_dockerfiles) -
+Dockerfiles to create build, run and test images for Dart applications across
+multiple architectures. Was deprecated when Arm supported landed in the
+official Dart Docker image, but brought back for RISC-V.
 * [At_Swarm_Load](https://github.com/atsign-company/at_swarm_load) -
 GCE Custom metrics for 5m load average and root volume utilisation.
 * [certinfo-action](https://github.com/atsign-company/certinfo-action) -
@@ -52,12 +60,7 @@ on our [Dev Blog](https://blog.atsign.dev/)
 
 ## We are proud to sponsor
 
-![EFF](https://atsign.com/wp-content/uploads/2021/10/2021-org-member-badge.png.webp)
-![Global Encryption Coalition](https://atsign.com/wp-content/uploads/2021/10/GEC-graphics-01-1.png.webp)
-
-## Deprecated
-
-* [at_dockerfiles](https://github.com/atsign-company/at_dockerfiles) -
-Dockerfiles to create build, run and test images for Dart applications across
-multiple architectures. No longer needed now that the official Dart Docker
-image supports multiple architectures.
+<!-- pyml disable-num-lines 3 md013,md033-->
+<img height=120px src="https://atsign.com/wp-content/uploads/2023/03/eff-2023-member-org.png.webp" alt="EFF Org Member">
+<img height=120px src="https://atsign.com/wp-content/uploads/2021/10/GEC-graphics-01-1.png.webp" alt="Global Encryption Coalition">
+<img height=120px src="https://atsign.com/wp-content/uploads/2023/08/LoRa-Alliance-horizontal600x300.png" alt="Lora Alliance">


### PR DESCRIPTION
Logo isn't showing on profile page since update to docs site

**- What I did**

* New logo line (from foundation pages)
* Updated deprecation status of at_dockerfiles
* New sponsor logos
* CRLF->LF

**- How to verify it**

Rich preview

**- Description for the changelog**

docs: Fix logo and other updates